### PR TITLE
allow to specify a custom path to 7za & cleanup scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepublish": "npm run build",
-    "build": "./node_modules/.bin/tsc",
-    "dev": "./node_modules/.bin/tsc --watch",
-    "lint": "./node_modules/.bin/eslint . --ext .ts",
-    "lint-fix": "./node_modules/.bin/eslint . --ext .ts --fix",
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .ts",
+    "lint-fix": "eslint . --ext .ts --fix",
     "test": "jest"
   },
   "author": "Jazcash",

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -33,7 +33,7 @@ export interface MapParserConfig {
      * Path to the 7za executable. Will automatically resolve if left unspecified.
      * @default sevenBin.path7za
      */
-    path7za?: string
+    path7za: string
 }
 
 const mapParserDefaultConfig: Partial<MapParserConfig> = {

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -29,12 +29,18 @@ export interface MapParserConfig {
      * @default false
      */
     skipSmt: boolean;
+    /**
+     * Path to the 7za executable. Will automatically resolve if left unspecified.
+     * @default undefined
+     */
+    path7za?: string
 }
 
 const mapParserDefaultConfig: Partial<MapParserConfig> = {
     verbose: false,
     mipmapSize: 4,
-    skipSmt: false
+    skipSmt: false,
+    path7za: undefined
 };
 
 export class MapParser {
@@ -114,8 +120,9 @@ export class MapParser {
 
             await fs.mkdir(outPath, { recursive: true });
 
+            const path7za = this.config.path7za ?? sevenBin.path7za;
             const extractStream = extractFull(sd7Path, outPath, {
-                $bin: sevenBin.path7za,
+                $bin: path7za,
                 recursive: true,
                 $cherryPick: ["*.smf", "*.smd", "*.smt", "mapinfo.lua"]
             });

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -120,7 +120,6 @@ export class MapParser {
 
             await fs.mkdir(outPath, { recursive: true });
 
-            const path7za = this.config.path7za ?? sevenBin.path7za;
             const extractStream = extractFull(sd7Path, outPath, {
                 $bin: this.config.path7za,
                 recursive: true,

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -31,7 +31,7 @@ export interface MapParserConfig {
     skipSmt: boolean;
     /**
      * Path to the 7za executable. Will automatically resolve if left unspecified.
-     * @default undefined
+     * @default sevenBin.path7za
      */
     path7za?: string
 }

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -122,7 +122,7 @@ export class MapParser {
 
             const path7za = this.config.path7za ?? sevenBin.path7za;
             const extractStream = extractFull(sd7Path, outPath, {
-                $bin: path7za,
+                $bin: this.config.path7za,
                 recursive: true,
                 $cherryPick: ["*.smf", "*.smd", "*.smt", "mapinfo.lua"]
             });

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -40,7 +40,7 @@ const mapParserDefaultConfig: Partial<MapParserConfig> = {
     verbose: false,
     mipmapSize: 4,
     skipSmt: false,
-    path7za: undefined
+    path7za: sevenBin.path7za
 };
 
 export class MapParser {


### PR DESCRIPTION
This fixes the problem where 7za distributed within an Electron app won't be included in the path provided by `7zip-bin`, which causes the whole app to crash due to a ENOENT for the 7zip executable. As a workaround, the Electron app can then provide the correct path to the 7zip executable, which I do in this fashion: `path7za = path7za.replace('app.asar', 'app.asar.unpacked');`


PS: I'm not entirely sure why a 7zip ENOENT causes the whole spring-launcher to crash, as I'm even capturing unhandled exceptions globally - yet while the error registers, it still crashes the process.