### PR TITLE
Improve failure modes, fix DXT1 lookup in transparency mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 dist
 node_modules
 /working-files
@@ -7,3 +8,4 @@ node_modules
 /texture.png
 /test.jpg
 /test.png
+/test/output/


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/maps-metadata/issues/567

When processing the DXT1 lookup on each block, there is a bug in color ordering, causing them to be swapped. This caused the 2-bit pixel indices to map to wrong colors, resulting in visible artifacts. This PR also updated the RGB565 conversion to use simple bit shifting instead of bit replication, which produces smoother gradients matching the reference python implementation.

This PR only updates the affected code, and does not make any of the necessary changes to publish the updated version to npm. Typically this would involve:

Updating package.json and package-lock.json with the new version
`npm run build`
`npm publsh` (whoever is running this will need to be authenticated with npm and have publish rights for the original npm package)