### PR TITLE
Provide option to export "dry" texture

### DIFF
--- a/src/map-model.ts
+++ b/src/map-model.ts
@@ -11,6 +11,7 @@ export type SpringMap = {
     smd?: SMD;
     smf?: SMF;
     textureMap?: Jimp;
+    textureMapDry?: Jimp;
     heightMap: Jimp;
     miniMap: Jimp;
     metalMap: Jimp;

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -100,14 +100,14 @@ export class MapParser {
             let smt: Jimp | undefined;
             let smtDry: Jimp | undefined;
             if (!this.config.skipSmt) {
-                smt = await this.parseSMT(archive.smt, smf.tileIndexMap, smf.mapWidthUnits, smf.mapHeightUnits, this.config.mipmapSize);
+                smtDry = await this.parseSMT(archive.smt, smf.tileIndexMap, smf.mapWidthUnits, smf.mapHeightUnits, this.config.mipmapSize);
             }
 
             const minHeight = mapInfo?.smf?.minheight ?? smd?.minHeight ?? smf?.minDepth;
             const maxHeight = mapInfo?.smf?.maxheight ?? smd?.maxHeight ?? smf?.maxDepth;
 
-            if (this.config.water && smt) {
-                smtDry = smt.cloneQuiet();
+            if (this.config.water && smtDry) {
+                smt = smtDry.cloneQuiet();
 
                 this.applyWater({
                     textureMap: smt,
@@ -148,7 +148,7 @@ export class MapParser {
                 metalMap: smf.metalMap,
                 miniMap: smf.miniMap,
                 typeMap: smf.typeMap,
-                textureMap: smt,
+                textureMap: smt ?? smtDry,
                 textureMapDry: smtDry,
                 resources
             };

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -98,6 +98,7 @@ export class MapParser {
             const smf = await this.parseSMF(archive.smf);
 
             let smt: Jimp | undefined;
+            let smtDry: Jimp | undefined;
             if (!this.config.skipSmt) {
                 smt = await this.parseSMT(archive.smt, smf.tileIndexMap, smf.mapWidthUnits, smf.mapHeightUnits, this.config.mipmapSize);
             }
@@ -106,6 +107,8 @@ export class MapParser {
             const maxHeight = mapInfo?.smf?.maxheight ?? smd?.maxHeight ?? smf?.maxDepth;
 
             if (this.config.water && smt) {
+                smtDry = smt.cloneQuiet();
+
                 this.applyWater({
                     textureMap: smt,
                     heightMapValues: smf.heightMapValues,
@@ -146,6 +149,7 @@ export class MapParser {
                 miniMap: smf.miniMap,
                 typeMap: smf.typeMap,
                 textureMap: smt,
+                textureMapDry: smtDry,
                 resources
             };
         } catch (err) {

--- a/test/map-parser.test.ts
+++ b/test/map-parser.test.ts
@@ -27,6 +27,9 @@ test("everything", async () => {
     await map.textureMap?.writeAsync("test/output/texture.png");
     expect(fs.existsSync("test/output/texture.png")).toBe(true);
 
+    await map.textureMapDry?.writeAsync("test/output/texture-dry.png");
+    expect(fs.existsSync("test/output/texture-dry.png")).toBe(true);
+
     await map.heightMap.quality(50).writeAsync("test/output/height.jpg");
     expect(fs.existsSync("test/output/height.jpg")).toBe(true);
 


### PR DESCRIPTION
Specifically, without re-processing the entire map file needlessly.

Necessary for https://github.com/beyond-all-reason/maps-metadata/issues/566