### PR TITLE
Add 'resources' config option for specific resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+# IDE-specific dirs
+.idea/
+
 dist
 node_modules
 /working-files
+/test/test_maps/*
+!/test/test_maps/barren_2.sd7
+!/test/test_maps/tropical-v2.sdz
 /tiles
 /out.png
 /height.jpg

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -53,6 +53,11 @@ export interface MapParserConfig {
      * @default false
      */
     parseResources: boolean;
+    /**
+     * List of specific resources to parse when parseResources: true
+     * @default undefined
+     */
+    resources?: string[];
 }
 
 const mapParserDefaultConfig: Partial<MapParserConfig> = {
@@ -534,6 +539,9 @@ export class MapParser {
             const value = resourceFiles[key];
 
             if (typeof value !== "string") {
+                continue;
+            }
+            if (this.config.resources && !this.config.resources.includes(key)) {
                 continue;
             }
 


### PR DESCRIPTION
Does not break backwards compatibility for `parseResources: true` where `resources` isn't defined.

Allows an array to be provided so that only specific resources are processed, in order to prevent wasting compute.

Is necessary/optimal for https://github.com/beyond-all-reason/maps-metadata/issues/569