### PR TITLE
Add husky + automatic linting pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^9.32.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.3.0",
+        "husky": "^9.1.7",
         "jaz-ts-utils": "^7.10.0",
         "jest": "^30.0.5",
         "ts-jest": "^29.4.1",
@@ -4163,6 +4164,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "test": "jest",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "author": "Jazcash and others",
   "license": "mit",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "tsc --watch",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky"
   },
   "author": "Jazcash and others",
   "license": "mit",
@@ -53,16 +54,17 @@
     "@types/jest": "^30",
     "@types/jimp": "^0.2.28",
     "@types/luaparse": "^0.2.7",
-    "@types/node-7z": "^2.1.0",
     "@types/node": "^16",
+    "@types/node-7z": "^2.1.0",
+    "eslint": "^9.32.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.3.0",
-    "eslint": "^9.32.0",
+    "husky": "^9.1.7",
     "jaz-ts-utils": "^7.10.0",
     "jest": "^30.0.5",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
-    "typescript-eslint": "^8.54.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.54.0"
   }
 }


### PR DESCRIPTION
Adds [husky ](https://www.npmjs.com/package/husky) and a pre-commit hook to run linting, minimizing needless CI errors

The `husky || true` in package.json is to ensure the CI/CD pipeline itself doesn't error if it doesn't install dev-dependencies