### PR TITLE
Reduce parseSMT memory usage and improve performance

### DIFF
--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -366,41 +366,47 @@ export class MapParser {
         const dxt1Size = Math.pow(mipmapSize, 2) / 2;
         const rowLength = mipmapSize * 4;
 
-        const refTiles: Buffer[][] = [];
-        for (let i=0; i<numOfTiles; i++) {
+        // Decode reference tiles as flat RGBA buffers (read-only, shared by index)
+        const refTiles: Buffer[] = [];
+        for (let i = 0; i < numOfTiles; i++) {
             const dxt1 = bufferStream.read(680).slice(startIndex, startIndex + dxt1Size);
-            const refTileRGBABuffer = parseDxt(dxt1, mipmapSize, mipmapSize);
-            const refTile: Buffer[] = [];
-            for (let k=0; k<mipmapSize; k++) {
-                const pixelIndex = k * rowLength;
-                const refTileRow = refTileRGBABuffer.slice(pixelIndex, pixelIndex + rowLength);
-                refTile.push(refTileRow);
-            }
-            refTiles.push(refTile);
+            refTiles.push(parseDxt(dxt1, mipmapSize, mipmapSize));
         }
 
-        const tiles: Buffer[][] = [];
-        for (let i=0; i<tileIndexes.length; i++) {
-            const refTileIndex = tileIndexes[i];
-            const tile = this.cloneTile(refTiles[refTileIndex]);
-            tiles.push(tile);
+        // Pre-allocate output buffer and blit tiles directly into position
+        const tilesWide = mapWidthUnits * 32;
+        const tilesHigh = mapHeightUnits * 32;
+        const outputWidth = mipmapSize * tilesWide;
+        const outputHeight = mipmapSize * tilesHigh;
+        const outputStride = outputWidth * 4;
+        const output = Buffer.alloc(outputWidth * outputHeight * 4);
+
+        if (tileIndexes.length !== tilesWide * tilesHigh) {
+            throw new Error(`Tile index count mismatch: expected ${tilesWide * tilesHigh}, got ${tileIndexes.length}`);
         }
 
-        const tileStrips: Buffer[] = [];
-        for (let y=0; y<mapHeightUnits * 32; y++) {
-            const tileStrip: Buffer[][] = [];
-            for (let x=0; x<mapWidthUnits * 32; x++) {
-                const tile = tiles.shift()!;
-                tileStrip.push(tile);
+        for (let tileIdx = 0; tileIdx < tileIndexes.length; tileIdx++) {
+            const refIndex = tileIndexes[tileIdx];
+            if (refIndex < 0 || refIndex >= refTiles.length) {
+                throw new Error(`Tile index ${refIndex} out of range (0..${refTiles.length - 1}) at position ${tileIdx}`);
             }
-            const textureStrip = this.joinTilesHorizontally(tileStrip, mipmapSize);
-            tileStrips.push(textureStrip);
+            const refTile = refTiles[refIndex];
+            const tileX = tileIdx % tilesWide;
+            const tileY = Math.floor(tileIdx / tilesWide);
+            const destXByte = tileX * mipmapSize * 4;
+            const destYRow = tileY * mipmapSize;
+
+            for (let row = 0; row < mipmapSize; row++) {
+                const srcOffset = row * rowLength;
+                const destOffset = (destYRow + row) * outputStride + destXByte;
+                refTile.copy(output, destOffset, srcOffset, srcOffset + rowLength);
+            }
         }
 
         return new Jimp({
-            data: Buffer.concat(tileStrips),
-            width: mipmapSize * mapWidthUnits * 32,
-            height: mipmapSize * mapHeightUnits * 32
+            data: output,
+            width: outputWidth,
+            height: outputHeight
         }).background(0x000000);
     }
 
@@ -502,26 +508,6 @@ export class MapParser {
             maxHeight: obj.maxheight,
             startPositions
         };
-    }
-
-    protected cloneTile(tile: Buffer[]) : Buffer[] {
-        const clone: Buffer[] = [];
-        for (const row of tile) {
-            clone.push(Buffer.from(row));
-        }
-        return clone;
-    }
-
-    protected joinTilesHorizontally(tiles: Buffer[][], mipmapSize: 4 | 8 | 16 | 32) : Buffer {
-        const tileRows: Buffer[] = [];
-        for (let y=0; y<mipmapSize; y++) {
-            for (let x=0; x<tiles.length; x++) {
-                const row = tiles[x].shift()!;
-                tileRows.push(row);
-            }
-        }
-
-        return Buffer.concat(tileRows);
     }
 
     protected applyWater(options: WaterOptions) {

--- a/src/map-parser.ts
+++ b/src/map-parser.ts
@@ -150,7 +150,11 @@ export class MapParser {
 
             let skybox: Jimp | undefined;
             if (this.config.parseSkybox && mapInfo?.atmosphere?.skyBox) {
-                skybox = await this.parseSkybox(tempArchiveDir, mapInfo.atmosphere.skyBox);
+                try {
+                    skybox = await this.parseSkybox(tempArchiveDir, mapInfo.atmosphere.skyBox);
+                } catch (err) {
+                    console.warn(`Error parsing skybox for "${mapInfo.atmosphere.skyBox}":`, err);
+                }
             }
 
             await this.cleanup(tempArchiveDir);


### PR DESCRIPTION
Related to #19 

### Work done

Rewrites tile assembly in `parseSMT` to blit decoded tiles directly into a pre-allocated output buffer instead of cloning, collecting, and concatenating them through multiple intermediate arrays.

The old code had three layers of intermediate buffers all in memory at once:
1. `refTiles[][]` — decoded reference tiles split into row-buffers
2. `tiles[][]` — full clone of every tile via `Buffer.from()` per row (500k+ tiles on large maps)
3. `tileStrips[]` — horizontal strips joined via `Buffer.concat()`
4. Final `Buffer.concat(tileStrips)` to produce the image

The new code decodes reference tiles as flat RGBA buffers, pre-allocates a single output buffer, and copies each tile's rows directly into position with `Buffer.copy()`. No cloning, no strips, no concat. Also eliminates `Array.shift()` on large arrays (O(n) per call, making the old strip assembly O(n²)).

Removes the now-unused `cloneTile` and `joinTilesHorizontally` methods.

Also wraps the `parseSkybox` call site in try/catch to match how `parseResources` handles errors — a missing or invalid skybox no longer crashes the entire parse.

### Results

Benchmarked against three maps at mipmap 4 and 16 (3 runs each, averaged):

| Map | Mipmap | Before | After | Speedup |
|-----|--------|--------|-------|---------|
| hooked (small) | 4 | 1,231ms | 958ms | 1.3x |
| kolmogorov (medium) | 4 | 15,009ms | 4,885ms | 3.1x |
| proving_grounds (large) | 4 | 41,326ms | 5,869ms | 7.0x |
| hooked (small) | 16 | 4,289ms | 1,058ms | 4.1x |
| kolmogorov (medium) | 16 | 17,438ms | 6,605ms | 2.6x |
| proving_grounds (large) | 16 | 38,657ms | 10,356ms | 3.7x |

Full regression across all 223 BAR maps at mipmap 4: all pass, all texture/height/metal/dry RGBA buffers hash identically before and after.

### AI / LLM usage statement

GitHub Copilot CLI (Claude Opus 4.6) used to assist in codebase analysis, implementation, benchmarking, and regression testing. All code was reviewed, directed, and verified by the contributor.
